### PR TITLE
Fix wrong name and typo in Shield 50 README

### DIFF
--- a/Shield 50/README.md
+++ b/Shield 50/README.md
@@ -5,7 +5,7 @@
 
 ![S50](https://capsule-render.vercel.app/api?type=venom&height=300&color=gradient&text=Shield%2050&animation=fadeIn&fontAlign=50&fontSize=110&reversal=false&section=header&fontColor=ffffff)
 
-Sword is a comphrensive collection of 50 methods to safeguard against prompt injections
+Shield is a comprehensive collection of 50 methods to safeguard against prompt injections
 
 ## **Training-Time Defenses**
 


### PR DESCRIPTION
## Summary
- Line 8 incorrectly says "Sword" instead of "Shield" — this is the Shield 50 document, not Sword 140
- Fixes typo "comphrensive" → "comprehensive"

## Test plan
- [ ] Verify line 8 of `Shield 50/README.md` now reads "Shield is a comprehensive collection"

🤖 Generated with [Claude Code](https://claude.com/claude-code)