### PR TITLE
Fix typo: articels → articles in Archive/Info.md

### DIFF
--- a/Archive/Info.md
+++ b/Archive/Info.md
@@ -2,4 +2,4 @@
 Welcome to ZetaLib's Archive. Here you will find various archived AI content!
 
 ## What will be archived?
-Anything AI related will be archived, since the Archiver Bot automatically archives AI articels
+Anything AI related will be archived, since the Archiver Bot automatically archives AI articles


### PR DESCRIPTION
## Summary
- Fixes spelling mistake "articels" → "articles" in Archive/Info.md line 6

## Test plan
- [ ] Verify the word is now correctly spelled "articles"

🤖 Generated with [Claude Code](https://claude.com/claude-code)